### PR TITLE
解决内存占用太多问题

### DIFF
--- a/FSPlayer/Media.cpp
+++ b/FSPlayer/Media.cpp
@@ -84,12 +84,18 @@ bool MediaState::openInput()
 
 int decode_thread(void *data)
 {
+        const long long  MAX_AUDIOQ_SIZE = (5 * 16 * 1024);
+	const long long   MAX_VIDEOQ_SIZE = (5 * 256 * 1024);
 	MediaState *media = (MediaState*)data;
 
 	AVPacket *packet = av_packet_alloc();
 
 	while (true)
 	{
+                if (media->audio->audioq.size > MAX_AUDIOQ_SIZE || media->video->videoq->size > MAX_VIDEOQ_SIZE) {
+			SDL_Delay(10);
+			continue;
+		}
 		int ret = av_read_frame(media->pFormatCtx, packet);
 		if (ret < 0)
 		{


### PR DESCRIPTION
解码的时候把每一帧读到内存中，一个小视频就占用两百多M，这里小小的修改可以减少内存占用